### PR TITLE
- disable middle cell on click

### DIFF
--- a/public/css/style.css
+++ b/public/css/style.css
@@ -145,3 +145,7 @@ clipboard-btn::after {
   text-align: center;
   font-style: italic;
 }
+
+.midCell {
+  cursor: not-allowed;
+}

--- a/public/js/script.js
+++ b/public/js/script.js
@@ -1,4 +1,5 @@
 import { addMessage } from "./socket.js";
+import {checkMiddles} from "./utility.js";
 
 const container = document.getElementById("grid-container");
 const startBtn = document.getElementById("button-start");
@@ -21,7 +22,7 @@ const handlePlayerPointer = (player) => {
   const turn = localStorage.getItem("turn");
   const cellValue = param.get("isHost");
 
-  if(turn != cellValue) return;
+  if(turn != cellValue || (checkMiddles(player.target.id) == false)) return;
 
   let cellId = player.target.id;
   let stage = localStorage.getItem('stage') || "PLAYING";

--- a/public/js/utility.js
+++ b/public/js/utility.js
@@ -101,4 +101,17 @@ export const resetGame = (evt) => {
   }
 };
 
+export const checkMiddles = (origCellId) => {
+  const cell =  document.getElementById(origCellId);
+ let newCellId = origCellId.slice(1);
+ let midPart = 3/2;
+
+  if (newCellId !== -1 && newCellId / 2 == midPart) {
+   cell.classList.add("midCell");
+   cell.contentEditable = false;
+  return false;
+  }
+
+}
+
 resetBtn.addEventListener("click", resetGame);


### PR DESCRIPTION
## What?
Disable move/click on middle cells

## Why?
This ensures consistency with side stack flow of the game

## How?
Currently middle cells are selected even when the sides are empty

## Anything Else?
![Untitled design](https://user-images.githubusercontent.com/26967919/146003792-c7debedb-1f10-4de0-9329-e2e0c05cc26d.gif)
